### PR TITLE
Added navigation after a post is created to its details page

### DIFF
--- a/src/components/posts/CreateAPost.jsx
+++ b/src/components/posts/CreateAPost.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from "react"
 import { PostPost } from "../../managers/PostServices"
 import { getAllCategories } from "../../managers/CategoryManager"
+import { useNavigate } from "react-router-dom"
 export const CreateAPost = ({token}) => {
+    const navigate = useNavigate()
     const [allCategories, setAllCategories]  = useState([])
     const [category, setCategory] = useState(0)
     const userId = token
@@ -30,7 +32,7 @@ export const CreateAPost = ({token}) => {
                 content: content.current.value,
                 approved: true
             }
-            PostPost(postForm)
+            PostPost(postForm).then((createdPost) => navigate(`/posts/${createdPost.id}`))
         }
     }
 

--- a/src/components/posts/CreateAPost.jsx
+++ b/src/components/posts/CreateAPost.jsx
@@ -1,73 +1,117 @@
-import { useEffect, useRef, useState } from "react"
-import { PostPost } from "../../managers/PostServices"
-import { getAllCategories } from "../../managers/CategoryManager"
-export const CreateAPost = ({token}) => {
-    const [allCategories, setAllCategories]  = useState([])
-    const [category, setCategory] = useState(0)
-    const userId = token
-    const title = useRef()
-    const image = useRef()
-    const content = useRef()
+import { useEffect, useState } from "react";
+import { PostPost } from "../../managers/PostServices";
+import { getAllCategories } from "../../managers/CategoryManager";
 
-    useEffect(() => {
-        getAllCategories().then((res) => setAllCategories(res))
-    }, [])
+export const CreateAPost = ({ token }) => {
+  const [publishDisabled, setPublishDisabled] = useState(true);
+  const [allCategories, setAllCategories] = useState([]);
+  const userId = parseInt(token);
 
-    const handleCategorySelect = (event) => {
-        setCategory(parseInt(event.target.value))
+  const [newPost, setNewPost] = useState({
+    user_id: userId,
+    category_id: 0,
+    title: "",
+    publication_date: new Date(),
+    image_url: "",
+    content: "",
+    approved: true,
+  });
+
+  useEffect(() => {
+    getAllCategories().then((res) => setAllCategories(res));
+  }, []);
+
+  useEffect(() => {
+    const shouldDisable = !(
+      newPost.title &&
+      newPost.content &&
+      newPost.category_id
+    );
+    setPublishDisabled(shouldDisable);
+  }, [newPost.category_id, newPost.content, newPost.title]);
+
+  const handlePostSubmission = (event) => {
+    event.preventDefault();
+
+    if (userId !== 0 && newPost.content) {
+      PostPost({
+        ...newPost,
+      });
     }
+  };
 
-    const handlePostSubmission = (event) => {
-        event.preventDefault()
-
-        if(userId !== 0 && content !== "") {
-            const postForm = {
-                user_id: userId,
-                category_id: category,
-                title: title.current.value,
-                publication_date: new Date(),
-                image_url: image.current.value,
-                content: content.current.value,
-                approved: true
-            }
-            PostPost(postForm)
-        }
-    }
-
-    return <>
-    <form className="box">
+  return (
+    <>
+      <form className="box">
         <h1 className="title">New Post</h1>
         <fieldset className="field">
-            <input className="input" type="text" placeholder="Title" ref={title}/>
+          <input
+            className="input"
+            type="text"
+            placeholder="Title"
+            onChange={({ target: { value } }) => {
+              setNewPost({
+                ...newPost,
+                title: value.trim(),
+              });
+            }}
+          />
         </fieldset>
         <fieldset className="field">
-            <input className="input" type="text" placeholder="ImageURL" ref={image}/>
+          <input
+            className="input"
+            type="text"
+            placeholder="Image URL"
+            onChange={({ target: { value } }) => {
+              setNewPost({
+                ...newPost,
+                image_url: value.trim(),
+              });
+            }}
+          />
         </fieldset>
         <fieldset className="field">
-            <textarea className="textarea" type="text" placeholder="Article Content" ref={content}/>
+          <textarea
+            className="textarea"
+            type="text"
+            placeholder="Article Content"
+            onChange={({ target: { value } }) => {
+              setNewPost({
+                ...newPost,
+                content: value.trim(),
+              });
+            }}
+          />
         </fieldset>
         <fieldset className="field">
-            {allCategories 
-            ?
-          <div
-          className="select"
-          >
-            <select 
-            onChange={handleCategorySelect}>
-                <option value="0">Category Select</option>
-                {allCategories.map((category) => {
-                    return <option value={category.id} key={category.id}>{category.label}</option>
-                })}
+          <div className="select">
+            <select
+              onChange={({ target: { value } }) => {
+                setNewPost({
+                  ...newPost,
+                  category_id: parseInt(value),
+                });
+              }}
+            >
+              <option value="0">Category Select</option>
+              {allCategories.map((category) => {
+                return (
+                  <option value={category.id} key={category.id}>
+                    {category.label}
+                  </option>
+                );
+              })}
             </select>
-            </div>
-            : ""}
-
+          </div>
         </fieldset>
         <button
-        className="button is-primary"
-        onClick={handlePostSubmission}>
-            Publish
+          disabled={publishDisabled}
+          className="button is-primary"
+          onClick={handlePostSubmission}
+        >
+          Publish
         </button>
-    </form>
+      </form>
     </>
-}
+  );
+};

--- a/src/components/posts/CreateAPost.jsx
+++ b/src/components/posts/CreateAPost.jsx
@@ -4,7 +4,7 @@ import { getAllCategories } from "../../managers/CategoryManager";
 
 import { useNavigate } from "react-router-dom"
 export const CreateAPost = ({ token }) => {
-    const navigate = useNavigate()
+  const navigate = useNavigate()
   const [publishDisabled, setPublishDisabled] = useState(true);
   const [allCategories, setAllCategories] = useState([]);
   const userId = parseInt(token);
@@ -38,7 +38,7 @@ export const CreateAPost = ({ token }) => {
     if (userId !== 0 && newPost.content) {
       PostPost({
         ...newPost,
-      });
+      }).then((createdPost) => navigate(`/posts/${createdPost.id}`));
     }
   };
 

--- a/src/components/posts/CreateAPost.jsx
+++ b/src/components/posts/CreateAPost.jsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from "react";
 import { PostPost } from "../../managers/PostServices";
 import { getAllCategories } from "../../managers/CategoryManager";
 
+import { useNavigate } from "react-router-dom"
 export const CreateAPost = ({ token }) => {
+    const navigate = useNavigate()
   const [publishDisabled, setPublishDisabled] = useState(true);
   const [allCategories, setAllCategories] = useState([]);
   const userId = parseInt(token);

--- a/src/components/posts/PostList.jsx
+++ b/src/components/posts/PostList.jsx
@@ -1,126 +1,175 @@
-import { useEffect, useState } from "react"
-import { getAllPosts, getAllPostTags } from "../../managers/PostManager"
-import { getAllCategories } from "../../managers/CategoryManager"
-import { getAllTags } from "../../managers/TagManager"
-import { getPostsByUserId } from "../../managers/PostServices"
-import { getAllUsers } from "../../managers/UserManager"
-import { HumanDate } from "../utils/HumanDate"
-import "../../Rare.css"
-export const PostList = ({token}) => {
-    const [posts, setPosts] = useState([])
-    const [categories, setCategories] = useState([])
-    const [tags, setTags] = useState([])
-    const [postTags, setPostTags] = useState([])
-    const [users, setUsers] = useState([])
-    const [filterCategory, setFilteredCategory] = useState(posts);
+import { useEffect, useState } from "react";
+import { getAllPosts, getAllPostTags } from "../../managers/PostManager";
+import { getAllCategories } from "../../managers/CategoryManager";
+import { getAllTags } from "../../managers/TagManager";
+import { getPostsByUserId } from "../../managers/PostServices";
 
-    useEffect(() => {
-        getAllPosts().then(postsArray => {
-            setPosts(postsArray)
-        })
-        getAllCategories().then(categoriesArray => {
-            setCategories(categoriesArray)
-        })
-        getAllTags().then(tagsArray => {
-            setTags(tagsArray)
-        })
-        getAllPostTags().then(postTagsArray => {
-            setPostTags(postTagsArray)
-        })
-        if (token) {
-            getPostsByUserId(token).then((postArray) => setPosts(postArray))
-        }
-    }, [token])
+import { HumanDate } from "../utils/HumanDate";
+import "../../Rare.css";
+export const PostList = ({ token }) => {
+  const [posts, setPosts] = useState([]);
+  const [categories, setCategories] = useState([]);
+  const [tags, setTags] = useState([]);
+  const [postTags, setPostTags] = useState([]);
+  const [filterCategory, setFilteredCategory] = useState(posts);
 
-    useEffect(() => {
-        setFilteredCategory(posts);
-    }, [posts]);
-
-    const handleDeletePost = (event) => {
-        console.log("Post Deleted!")
+  useEffect(() => {
+    getAllPosts().then((postsArray) => {
+      setPosts(postsArray);
+    });
+    getAllCategories().then((categoriesArray) => {
+      setCategories(categoriesArray);
+    });
+    getAllTags().then((tagsArray) => {
+      setTags(tagsArray);
+    });
+    getAllPostTags().then((postTagsArray) => {
+      setPostTags(postTagsArray);
+    });
+    if (token) {
+      getPostsByUserId(token).then((postArray) => setPosts(postArray));
     }
+  }, [token]);
 
-    const handleEditPost = (event) => {
-        console.log("Navigating to post editing!")
+  useEffect(() => {
+    setFilteredCategory(posts);
+  }, [posts]);
+
+  const handleDeletePost = () => {
+    console.log("Post Deleted!");
+  };
+
+  const handleEditPost = () => {
+    console.log("Navigating to post editing!");
+  };
+
+  const handleFormChange = (event) => {
+    if (event.target.value === "default") {
+      setFilteredCategory(posts);
+    } else {
+      let filteredPost = posts.filter(
+        (post) => post.category_id === parseInt(event.target.value),
+      );
+      setFilteredCategory(filteredPost);
     }
+  };
 
-    const handleFormChange = (event) => {
-        if(event.target.value === "default"){
-            setFilteredCategory(posts)
-        } else{
-            let filteredPost = posts.filter(post => post.category_id === parseInt(event.target.value))
-            setFilteredCategory(filteredPost)            
-        }
-    }
+  return (
+    <div key="container">
+      <select className="ml-3 control" onChange={handleFormChange}>
+        <option key="0" value="default">
+          All Categories...
+        </option>
+        {categories.map((category) => {
+          return (
+            <option key={category.id} value={category.id}>
+              {category.label}
+            </option>
+          );
+        })}
+      </select>
 
-    return (
-        <div key="container">
-            <select className="ml-3 control" onChange={handleFormChange}>
-                    <option key="0" value="default">All Categories...</option>
-                    {categories.map((category) => {
-                        return (
-                            <option key={category.id} value={category.id}>{category.label}</option>
-                        )
-                    })}
-                </select>
-                    
-            {filterCategory.map((post) => {
+      {filterCategory.map((post) => {
+        let postCategory = categories.find(
+          (category) => category.id === post.category_id,
+        );
 
-                let postCategory = categories.find(category => category.id === post.category_id)
+        let postTagArr = postTags.filter(
+          (postTag) => postTag.post_id === post.id,
+        );
 
-                let postTagArr = postTags.filter(postTag => postTag.post_id === post.id)
-                
-                let relatedTags = postTagArr.flatMap(postTag =>
-                    tags.filter(tag => tag.id === postTag.tag_id)
-                );
+        let relatedTags = postTagArr.flatMap((postTag) =>
+          tags.filter((tag) => tag.id === postTag.tag_id),
+        );
 
-                let postUser = users.find(user => user.id === post.user_id)
-                
-                // Shared component, used for Post List and My Posts components. 
-                return (
-                    <div key={post.id}>
-                        {/* First returns expression. Displays current user's posts at My Posts */}
-                    {token 
-                    ? <div className="card mb-3 p-2">
-                    {/* Second statement returns all posts, there is no token being accepted in this view. */}
+        // Shared component, used for Post List and My Posts components.
+        return (
+          <div key={post.id}>
+            {/* First returns expression. Displays current user's posts at My Posts */}
+            {token ? (
+              <div className="card mb-3 p-2">
+                {/* Second statement returns all posts, there is no token being accepted in this view. */}
                 <div className="title">{post.title}</div>
-                <section className="mx-4 level is-size-4">{postCategory ? postCategory.label : ""}
-                    <div className="is-size-6">{<HumanDate date={post.publication_date.split("T")[0]} />}</div>
+                <section className="mx-4 level is-size-4">
+                  {postCategory ? postCategory.label : ""}
+                  <div className="is-size-6">
+                    {<HumanDate date={post.publication_date.split("T")[0]} />}
+                  </div>
                 </section>
-                    <div className="image_container">
-                        <img className="image" src={post.image_url} alt="placeholder" />
+                <div className="image_container">
+                  <img
+                    className="image"
+                    src={post.image_url}
+                    alt="placeholder"
+                  />
                 </div>
                 <footer className="level">
-                    <div className="ml-4">Author</div>
-                    <div>{ relatedTags ? relatedTags.map(tag => tag.label).join(", ") : ""}</div>
-                <div className="is-pulled-right">
-                    <button className="button is-primary" onClick={handleEditPost}><i className="fa-solid fa-edit"></i></button>
-                    <button className="button is-danger" onClick={handleDeletePost}><i className="fa-solid fa-trash-can"></i></button>
-                </div >
+                  <div className="ml-4">Author: {post.full_name}</div>
+                  <div>
+                    {relatedTags
+                      ? relatedTags.map((tag) => tag.label).join(", ")
+                      : ""}
+                  </div>
+                  <div className="is-pulled-right">
+                    <button
+                      className="button is-primary"
+                      onClick={handleEditPost}
+                    >
+                      <i className="fa-solid fa-edit"></i>
+                    </button>
+                    <button
+                      className="button is-danger"
+                      onClick={handleDeletePost}
+                    >
+                      <i className="fa-solid fa-trash-can"></i>
+                    </button>
+                  </div>
                 </footer>
-        </div>
-                    : <div className="card mb-3 p-2">
-                        {/* Second statement returns all posts, there is no token being accepted in this view. */}
-                    <div className="title">{post.title}</div>
-                    <section className="mx-4 level is-size-4">{postCategory ? postCategory.label : ""}
-                        <div className="is-size-6">{<HumanDate date={post.publication_date.split("T")[0]} />}</div>
-                    </section>
-                        <div className="image_container">
-                            <img className="image" src={post.image_url} alt="placeholder" />
-                    </div>
-                    <footer className="level">
-                        <div className="ml-4">Author</div>
-                        <div>{ relatedTags ? relatedTags.map(tag => tag.label).join(", ") : ""}</div>
-                    <div className="is-pulled-right">
-                        <button className="button is-primary" onClick={handleEditPost}><i className="fa-solid fa-edit"></i></button>
-                        <button className="button is-danger" onClick={handleDeletePost}><i className="fa-solid fa-trash-can"></i></button>
-                    </div >
-                    </footer>
-            </div>}
-        </div>
-                );
-            })}
+              </div>
+            ) : (
+              <div className="card mb-3 p-2">
+                {/* Second statement returns all posts, there is no token being accepted in this view. */}
+                <div className="title">{post.title}</div>
+                <section className="mx-4 level is-size-4">
+                  {postCategory ? postCategory.label : ""}
+                  <div className="is-size-6">
+                    {<HumanDate date={post.publication_date.split("T")[0]} />}
+                  </div>
+                </section>
+                <div className="image_container">
+                  <img
+                    className="image"
+                    src={post.image_url}
+                    alt="placeholder"
+                  />
+                </div>
+                <footer className="level">
+                  <div className="ml-4">Author: {post.full_name}</div>
+                  <div>
+                    {relatedTags
+                      ? relatedTags.map((tag) => tag.label).join(", ")
+                      : ""}
+                  </div>
+                  <div className="is-pulled-right">
+                    <button
+                      className="button is-primary"
+                      onClick={handleEditPost}
+                    >
+                      <i className="fa-solid fa-edit"></i>
+                    </button>
+                    <button
+                      className="button is-danger"
+                      onClick={handleDeletePost}
+                    >
+                      <i className="fa-solid fa-trash-can"></i>
+                    </button>
+                  </div>
+                </footer>
+              </div>
+            )}
+          </div>
+        );
+      })}
     </div>
-    )
-}
-
+  );
+};


### PR DESCRIPTION
**What**
There was a found bug in the `Create A Post` form. As per the requirements, the user is meant to be navigated to the post details of their recently submitted post. 

**How can I test this?**
Currently, the Post Details component is still in development. Nevertheless, the pathing for the navigation is set up correctly. Simply, fill out the form on the `Create A Post` component, click the "Publish" button, and watch as you are elegantly navigated to the Post Details view. 

**Issue**
This is the front-end half of the issue ticket #40. Previously, the user was not being navigated at all to the post's details that they had created. Instead, they saw the post form filled out, but no visual indication that the process had taken place. 

**Files Changed**
Changed: `src/components/posts/CreateAPost.jsx` (line 35) Receives the response body, and navigates to the post's details page. 