### PR TITLE
FEAT: Implemented Post Comments Page and Updated Routing (#23)

### DIFF
--- a/src/components/posts/PostComments.jsx
+++ b/src/components/posts/PostComments.jsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { getAllComments } from "../../managers/CommentManager";
+
+export const PostComments = () => {
+    const { postId } = useParams()
+    const [comments, setComments] = useState([])
+
+    useEffect(() => {
+        getAllComments().then(commentObj => {
+            setComments(commentObj)
+        })
+
+        
+    }, [])
+        let relatedComments = comments.filter(comment => comment.post_id === parseInt(postId))
+        return (
+            <section className="section">
+              <div className="container">
+                <div className="columns is-centered">
+                  <div className="column is-half">
+                    <h2 className="title is-4">Comments</h2>
+                    
+                    {relatedComments.length > 0 ? (
+                      relatedComments.map((comment) => (
+                        <article key={comment.comment_id} className="box ">
+                          {/* Comment Content */}
+                          <div className="content">
+                            <p>
+                              <strong>{comment.author_name}</strong>
+                              <br />
+                              {comment.content}
+                            </p>
+                          </div>
+                        </article>
+                      ))
+                    ) : (
+                      <p>No comments yet.</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </section>
+          )
+          
+          
+      
+
+}

--- a/src/components/posts/PostDetails.jsx
+++ b/src/components/posts/PostDetails.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { getPostsByPostId } from "../../managers/PostServices";
 
 export const PostDetails = ({ token }) => {
@@ -13,7 +13,7 @@ export const PostDetails = ({ token }) => {
             setPost(postObj)
         })
     }, [token, postId])
-    
+
 
     return (
         <section className="section">
@@ -22,17 +22,20 @@ export const PostDetails = ({ token }) => {
                 <div>{post?.publication_date}</div>
                 <div className="columns is-centered">
                     <div className="column is-half">
-                    <h1 className="title is-2 has-text-centered">{post?.title}</h1>
+                        <h1 className="title is-2 has-text-centered">{post?.title}</h1>
                         <figure className="image is-16by9">
-                            <img src={post?.image_url} alt="Post Image"/>
+                            <img src={post?.image_url} alt="Post Image" />
                         </figure>
                     </div>
                 </div>
                 <div className="columns is-centered">
                     <div className="column is-half has-text-centered">
-                        
+
                         <h2 className="content is-size-5 has-text-left title ">By {post?.full_name}</h2>
-                        <p className="content is-size-5">{post?.content}</p>
+                        <p className="content is-size-5">{post?.post_content}</p>
+                        <Link to={`/posts/${postId}/comments`}>
+                            <button>View Comments</button>
+                        </Link>
                     </div>
                 </div>
             </div>

--- a/src/managers/CommentManager.js
+++ b/src/managers/CommentManager.js
@@ -1,0 +1,3 @@
+export const getAllComments = () => {
+	return fetch("http://localhost:8088/comments").then((res) => res.json());
+};

--- a/src/views/ApplicationViews.js
+++ b/src/views/ApplicationViews.js
@@ -10,6 +10,7 @@ import { PostDetails } from "../components/posts/PostDetails";
 import UserDetails from "../components/user/UserDetails";
 import UserList from "../components/user/UserList";
 import SubscribedPosts from "../components/posts/SubscribedPosts";
+import {PostComments} from "../components/posts/PostComments"
 
 export const ApplicationViews = ({ token, setToken }) => {
   return (
@@ -28,6 +29,7 @@ export const ApplicationViews = ({ token, setToken }) => {
           <Route index element={<PostList />} />
           <Route path=":postId" element={<PostDetails token={token} />} />
         </Route>
+        <Route path="/posts/:postId/comments" element={<PostComments/>} />
         <Route path="/users">
           <Route index element={<UserList token={token} />} />
           <Route path=":userId" element={<UserDetails token={token} />} />\


### PR DESCRIPTION
**What?**
I've implemented the Post Comments page as part of ticket #23, allowing users to view comments associated with a specific post. This includes updating the application routes, creating a PostComments component, and adding CommentManager to retrieve comment data.

**Why?**
Previously, there was no dedicated page for viewing comments related to a post. This update ensures that when users click "View Comments" on a post detail page, they are directed to a new page that displays only that post's comments.

**How?**
Added a new route <Route path="/posts/:postId/comments" element={<PostComments/>} /> to handle navigation to the comments page. Created the PostComments component, which uses useParams to extract postId from the URL and getAllComments from CommentManager to fetch comments. The component filters comments to only display those related to the specified post..

**Testing?**
Manually tested navigation from the post detail page to ensure clicking "View Comments" correctly loads the related post’s comments. Verified that only comments belonging to the selected post are displayed. Also tested cases where a post has no comments to confirm the "No comments yet" message appears as expected.

**Related Backend Work**
I added a new endpoint in the backend to retrieve all comments. The update includes a Comment class with a get_all method and a new route in server.py to handle requests for comments.