### PR TITLE
Fixed bug: subscriptions would not fetch after subscribing

### DIFF
--- a/src/components/user/UserDetails.jsx
+++ b/src/components/user/UserDetails.jsx
@@ -48,7 +48,7 @@ const UserDetails = ({ token }) => {
       follower_id: parseInt(token),
       author_id: user?.id,
     };
-    createNewSubscription(subscriptionForm).then(navigate("/"));
+    createNewSubscription(subscriptionForm).then(() => navigate("/"));
   };
 
   return (


### PR DESCRIPTION
**What**
There was a small bug that would not fetch a user's subscriptions after they have subscribed. 

**Why**
The original issue required that once a user subscribed to another, they would be navigated back to the landing page, where they would see their subscriptions. However, once the user did subscribe, they received the fallback message about curating their subscriptions list. 

**Bugs**
1. Posts of the user that a user subscribed to would not be displayed once they were navigated back to the landing page. 

**Files Changed** 
Changed: `src/components/user/UserDetails.jsx` Line 51. Added an anonymous function call in the `.then` chain; this allows for the subscription to be posted to the database before the user was redirected. Once the user is redirected, the posts of the user to whom they subscribed will display